### PR TITLE
fix: decouple get and options request handling

### DIFF
--- a/src/bin/figmaid.rs
+++ b/src/bin/figmaid.rs
@@ -1,4 +1,4 @@
-use figmaid::{cli::*, config::load_config, font_metadata, server::start_server};
+use figmaid::{cli::cli, cli::config, config::load_config, font_metadata, server::start_server};
 
 #[tokio::main]
 async fn main() {
@@ -8,12 +8,12 @@ async fn main() {
         Some(("config", config)) => {
             match config.subcommand() {
                 Some(("create", _)) => {
-                    create(false);
+                    config::create(false);
                 }
                 Some(("validate", _)) => {
-                    validate().await;
+                    config::validate().await;
                 }
-                Some(("open", _)) => open(),
+                Some(("open", _)) => config::open(),
                 _ => {
                     let config = load_config();
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,16 +44,13 @@ pub async fn validate() {
                 eprintln!("Configuration is not valid JSON.")
             }
         }
-        Err(e) => {
-            if e.kind() == ErrorKind::NotFound {
-                eprintln!(
-                    "Validation failed because the configuration file hasn't been created.\
+        Err(e) => match e.kind() {
+            ErrorKind::NotFound => eprintln!(
+                "Validation failed because the configuration file hasn't been created.\
                    \n-> run `figmaid config create` to create it."
-                )
-            } else {
-                eprintln!("Couldn't validate because of io error: {}", e)
-            }
-        }
+            ),
+            _ => eprintln!("Couldn't validate because of io error: {}", e),
+        },
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,10 +38,12 @@ pub async fn validate() {
         Ok(config) => {
             let config = serde_json::from_slice(&config);
 
-            if config.is_ok() && is_config_valid(&config.unwrap()).await {
-                println!("Configuration is OK.")
-            } else {
-                eprintln!("Configuration is not valid JSON.")
+            match (config.is_ok(), is_config_valid(&config.unwrap()).await) {
+                (true, true) => println!("Configuration is OK."),
+
+                (true, false) => eprintln!("Configuration is not valid."),
+
+                (false, _) => eprintln!("Configuration is not valid JSON."),
             }
         }
         Err(e) => match e.kind() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,7 @@ pub async fn validate() {
 
     match std::fs::read(config_path) {
         Ok(config) => {
-            let config = serde_json::from_str(&String::from_utf8_lossy(&config));
+            let config = serde_json::from_slice(&config);
 
             if config.is_ok() && is_config_valid(&config.unwrap()).await {
                 println!("Configuration is OK.")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,7 +34,7 @@ fn config_exists(config_path: &PathBuf) -> bool {
 pub async fn validate() {
     let config_path = get_config_path();
 
-    match std::fs::read(config_path.clone()) {
+    match std::fs::read(config_path) {
         Ok(config) => {
             let config = serde_json::from_str(&String::from_utf8_lossy(&config));
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,25 +1,8 @@
-use clap::{crate_version, Command as Cmd};
 use std::fs::File;
 use std::io::{self, stdout, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use crate::config::{is_config_valid, Config};
-
-pub fn cli() -> Cmd<'static> {
-    Cmd::new("figmaid")
-        .version(crate_version!())
-        .about("Web server that allows you to use locally installed fonts in Figma")
-        .subcommand(
-            Cmd::new("config")
-                .about(
-                    "Create, open and validate configuration\
-                \n\nRun without subcommands to print current directories and amount of loaded fonts",
-                )
-                .subcommand(Cmd::new("create").about("Create default configuration file"))
-                .subcommand(Cmd::new("validate").about("Validate configuration"))
-                .subcommand(Cmd::new("open").about("Open configuration file in text editor")),
-        )
-}
 
 fn get_config_path() -> PathBuf {
     Path::new(&home::home_dir().expect("Couldn't get home directory"))

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,19 @@
+pub mod config;
+
+use clap::{crate_version, Command as Cmd};
+
+pub fn cli() -> Cmd<'static> {
+    Cmd::new("figmaid")
+        .version(crate_version!())
+        .about("Web server that allows you to use locally installed fonts in Figma")
+        .subcommand(
+            Cmd::new("config")
+                .about(
+                    "Create, open and validate configuration\
+                \n\nRun without subcommands to print current directories and amount of loaded fonts",
+                )
+                .subcommand(Cmd::new("create").about("Create default configuration file"))
+                .subcommand(Cmd::new("validate").about("Validate configuration"))
+                .subcommand(Cmd::new("open").about("Open configuration file in text editor")),
+        )
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -29,14 +29,15 @@ pub async fn figma(req: Request<Body>) -> Result<Response<Body>, Infallible> {
         .body(Body::empty())
         .unwrap();
 
-    match (req.uri().path(), req.method()) {
-        (FIGMA_FONT_FILES, &Method::GET | &Method::OPTIONS) => {
-            handle_font_files(config, &mut response)
-        }
-        (FIGMA_FONT_FILE, &Method::GET | &Method::OPTIONS) => handle_font_file(req, &mut response),
-        _ => {
-            *response.status_mut() = StatusCode::BAD_REQUEST;
-        }
+    match req.uri().path() {
+        FIGMA_FONT_FILES => handle_font_files(config, &mut response),
+        FIGMA_FONT_FILE => handle_font_file(req, &mut response),
+        _ => match req.method() {
+            &Method::OPTIONS => {}
+            _ => {
+                *response.status_mut() = StatusCode::BAD_REQUEST;
+            }
+        },
     };
 
     Ok(response)

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,11 +1,11 @@
 //! Handles requests to figma routes.
-//! - GET|OPTIONS `/figma/font-files` for a JSON file of all loaded fonts.
-//! - GET|OPTIONS `/figma/font-file` for a single font file.
+//! - GET `/figma/font-files` for a JSON file of all loaded fonts.
+//! - GET `/figma/font-file` for a single font file.
 //!
-//! OPTIONS is provided for CORS preflight requests with adequate response headers.
+//! OPTIONS is provided for CORS preflight requests with adequate response headers to all routes.
 //!
-//! Attempt to access other routes is considered an error from the user (should be Figma)
-//! and Bad Request is sent as a status code with empty body.
+//! Attempt to GET other routes is considered an error from the user (should be Figma)
+//! and 400 (Bad Request) is sent as a status code with empty body.
 
 use hyper::{body::Bytes, header::HeaderValue, Body, Method, Request, Response, StatusCode};
 use regex::Regex;


### PR DESCRIPTION
- refactor: use match expression instead of if else
- fix: remove unnecessary clone
- fix: remove preliminary conversion to string and use vector directly
- feat: improve validation error message
- refactor: remove side effect
- refactor: move configuration specific cli actions to own module
- fix: don't parse font metadata for options requests
